### PR TITLE
Fix an error when uploading an apk with a huge commit message.

### DIFF
--- a/src/main/kotlin/data/Commit.kt
+++ b/src/main/kotlin/data/Commit.kt
@@ -36,18 +36,6 @@ data class Commit(
     )
   }
 
-  fun validate(): Boolean {
-    if (commitHash.isBlank() || commitHash.length > MAX_HASH_LENGTH) {
-      return false
-    }
-
-    if (description.isBlank() || description.length > MAX_DESCRIPTION_LENGTH) {
-      return false
-    }
-
-    return true
-  }
-
   override fun equals(other: Any?): Boolean {
     if (other == null) {
       return false
@@ -83,7 +71,7 @@ data class Commit(
   }
 
   companion object {
-    const val MAX_DESCRIPTION_LENGTH = 1024
+    const val MAX_DESCRIPTION_LENGTH = 2048
     const val MAX_UUID_LENGTH = 96
     const val MAX_HASH_LENGTH = 64
 

--- a/src/main/kotlin/handler/UploadHandler.kt
+++ b/src/main/kotlin/handler/UploadHandler.kt
@@ -266,7 +266,6 @@ open class UploadHandler : AbstractHandler() {
     return Result.success(insertResult.getOrNull()!!)
   }
 
-
   private fun getFiles(fileUploads: Set<FileUpload>): Pair<FileUpload?, FileUpload?> {
     val apkFile = fileUploads.firstOrNull { file -> file.name() == APK_FILE_NAME }
     val commitsFile = fileUploads.firstOrNull { file -> file.name() == COMMITS_FILE_NAME }

--- a/src/main/kotlin/server/ServerSettings.kt
+++ b/src/main/kotlin/server/ServerSettings.kt
@@ -10,8 +10,8 @@ open class ServerSettings(
   open val secretKey: String,
   open val sslCertDirPath: String,
   open val apkName: String = "kuroba-dev",
-  // ~10MB per apk * 1000 ~= 10GB
-  open val maxApkFiles: Int = 1000,
+  // ~10MB per apk * 250 ~= 2500MB
+  open val maxApkFiles: Int = 250,
   open val apkDeletionInterval: Long = TimeUnit.MINUTES.toMillis(5),
   open val serverStateSavingInterval: Long = TimeUnit.HOURS.toMillis(1),
   open val listApksPerPageCount: Int = 50,


### PR DESCRIPTION
Closes #13 

- Trim the latest part of the commit description and ellipsize it at the end.
- Increase the max commit description length up to 2048 characters.
- Decrease the maximum amount of stored apk down to 250. We need this because we are
about to store apks for two different apps (Kuroba and KurobaEx). Also this is needed
to decrease the RAM consumption.
- Increase the amount of apks getting deleted at a time up to 25% (instead of 10%).